### PR TITLE
Add Artifact.repository to make it possible to reuse the class

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ In short, the *Maven Easy Index* has the following features:
 - Container and libraries are available through the GitHub package registry.
 
 
+[central]: https://repo1.maven.org/maven2/
 [index]: https://repo1.maven.org/maven2/.index/
 [index-read]: https://maven.apache.org/repository/central-index.html
 [guice]: https://github.com/google/guice
@@ -106,6 +107,10 @@ The individual entries contain the following information, separated by `:`
 - The coordinate, consisting of the `groupId`, `artifactId`, and `version`
 - The `packaging` of the coordinate (e.g., `jar` or `pom`)
 - The `release date` (in milliseconds)
+- The `repository` is implicitely set to [Maven Central][central] when missing.
+
+**Please Note:** If the `Artifact` class is used with repositories other than [Maven Central][central], the repository will be automatically included in the serialized JSON, e.g., `g:a:v:123@http://your.repo`.
+
 
 #### Access Artifacts Programmatically
 

--- a/data/src/main/java/dev/c0ps/maveneasyindex/Artifact.java
+++ b/data/src/main/java/dev/c0ps/maveneasyindex/Artifact.java
@@ -27,6 +27,8 @@ public class Artifact {
     public String version;
     public String packaging;
 
+    public String repository;
+
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
@@ -44,6 +46,8 @@ public class Artifact {
                 .append(artifactId).append(':') //
                 .append(version).append(':') //
                 .append(packaging).append(':') //
-                .append(releaseDate).toString();
+                .append(releaseDate).append('@') //
+                .append(repository) //
+                .toString();
     }
 }

--- a/data/src/test/java/dev/c0ps/maveneasyindex/ArtifactTest.java
+++ b/data/src/test/java/dev/c0ps/maveneasyindex/ArtifactTest.java
@@ -24,66 +24,75 @@ public class ArtifactTest {
 
     @Test
     public void equality() {
-        var a = a("g", "a", "v", "p", 1234);
-        var b = a("g", "a", "v", "p", 1234);
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g", "a", "v", "p", 1234, "r");
         assertEquals(a, b);
         assertEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void equality_diffGroup() {
-        var a = a("g", "a", "v", "p", 1234);
-        var b = a("g2", "a", "v", "p", 1234);
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g2", "a", "v", "p", 1234, "r");
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void equality_diffArtifact() {
-        var a = a("g", "a", "v", "p", 1234);
-        var b = a("g", "a2", "v", "p", 1234);
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g", "a2", "v", "p", 1234, "r");
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void equality_diffVersion() {
-        var a = a("g", "a", "v", "p", 1234);
-        var b = a("g", "a", "v2", "p", 1234);
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g", "a", "v2", "p", 1234, "r");
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void equality_diffPkg() {
-        var a = a("g", "a", "v", "p", 1234);
-        var b = a("g", "a", "v", "p2", 1234);
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g", "a", "v", "p2", 1234, "r");
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void equality_diffRelease() {
-        var a = a("g", "a", "v", "p", 1234);
-        var b = a("g", "a", "v", "p", 2345);
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g", "a", "v", "p", 2345, "r");
+        assertNotEquals(a, b);
+        assertNotEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equality_diffRepository() {
+        var a = a("g", "a", "v", "p", 1234, "r");
+        var b = a("g", "a", "v", "p", 2345, "r2");
         assertNotEquals(a, b);
         assertNotEquals(a.hashCode(), b.hashCode());
     }
 
     @Test
     public void hasToString() {
-        var actual = a("g", "a", "v", "p", 1234).toString();
-        var expected = "g:a:v:p:1234";
+        var actual = a("g", "a", "v", "p", 1234, "r").toString();
+        var expected = "g:a:v:p:1234@r";
         assertEquals(expected, actual);
     }
 
-    private static Artifact a(String g, String a, String v, String p, long r) {
+    private static Artifact a(String g, String a, String v, String p, long rel, String rep) {
         var res = new Artifact();
         res.groupId = g;
         res.artifactId = a;
         res.version = v;
         res.packaging = p;
-        res.releaseDate = r;
+        res.releaseDate = rel;
+        res.repository = rep;
         return res;
     }
 }

--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -10,6 +10,7 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- the following dependencies require an exact version -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
@@ -19,6 +20,11 @@
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>6.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.5.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -34,7 +40,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -61,12 +67,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
@@ -98,7 +104,7 @@
         <dependency>
             <groupId>dev.c0ps</groupId>
             <artifactId>commons</artifactId>
-            <version>0.0.5</version>
+            <version>0.0.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -136,17 +142,16 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>9.7.0</version>
+            <version>9.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-classworlds</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
We reuse the `Artifact` class outside the immediate index parsing to represents artifacts that might come from other repositories as well. To acknowledge that Maven Central is by far the most common repository, it will not be included in the serialized JSON and implicitly used when unset.